### PR TITLE
FIxes Stack Overflow in `nixSnippet`

### DIFF
--- a/codeSnippets.nix
+++ b/codeSnippets.nix
@@ -36,6 +36,12 @@ conix: { lib = rec
           inherit output;
         };
 
+    docs.printNixVal.docstr = ''
+      Pretty print a pure nix-value. 
+
+      NOTE: do not call this function on a derivation as it will segfault.
+      '';
+    docs.printNixVal.type = "a -> String";
     printNixVal = e:
       if builtins.isAttrs e then printAttrs e
       else if builtins.isList e then printList e
@@ -61,29 +67,25 @@ conix: { lib = rec
       in
         "[ ${printElems} ]";
 
-    docs.nixSnippet.docstr = ''
-      Create a module using the given nix snippet code and
-      the evaluated result.
-     
-      The text is markdown (see snippet for the template)
+    docs.runSnippet.docstr = ''
+      Create a module using the given code snippet and a function that accepts
+      the a nix store filepath containing the code.  `mkCode` handles executing
+      the code file and producing the output expected by `snippet` 
     '';
-    docs.nixSnippet.todo = [
-      ''
-      This fails in an stack overflow / infinite recursion issue if:
-
-        * the code is importing conix via a fetch git (using `./git.nix`)
-        * and we're building the conix documentation.
-
-        For example the `readme/sample.nix` works on its own, however if its
-        text is passed in as the `code` argument inside of the readme derivation
-        we get infinite recursion.
-      ''
-    ];
-    docs.nixSnippet.type = "Name -> String -> Module";
-    nixSnippet = name: code: evalNixFilePath:
+    docs.runSnippet.type = "Name -> String -> String -> (FilePath -> String) -> Module";
+    runSnippet = name: language: code: mkOutput:
       let
-        nixFile = conix.pkgs.writeText "${name}.nix" code;
+        codeFile = conix.pkgs.writeText "${name}.${language}" code;
       in
-        conix.lib.set name (snippet "nix" code "${printNixVal (import nixFile)}");
+        conix.lib.set name (snippet language code (mkOutput codeFile));
+
+    docs.runNixSnippetDrvFile.docstr = ''
+      Run `runSnippet` for nix code that evaluates to a derivation that points
+      to a single file. The output of the snippet is the contents of the file
+      resulting from the derivation.
+      '';
+    docs.runNixSnippetDrvFile.type = "Name -> String -> Module";
+    runNixSnippetDrvFile = name: code: 
+      runSnippet name "nix" code (nixFilePath: "${builtins.readFile (import nixFilePath)}");
   };
 }

--- a/git.nix
+++ b/git.nix
@@ -2,8 +2,8 @@ conix: { lib = rec
   { git =
     rec
     { url = "https://github.com/theNerd247/conix.git"; 
-      rev = "84d98837829587ce3ba2761f5d76e5d9da0c34d9";
-      ref = "v0.1.0-api";
+      rev = "d81bf467cd03ed47e3c62746febb4d7996bae1d8";
+      ref = "master";
       text = ''
         { url = "${url}";
           rev = "${rev}";

--- a/readme/default.nix
+++ b/readme/default.nix
@@ -25,16 +25,39 @@ To try out conix:
 1. Open the `result/Volunteers.md` file. ''#TODO: replace with generated html file.
 ''
 
+''(runNixSnippetDrvFile "sampleConix" ''
+(import <nixpkgs> { 
+  overlays = import (builtins.fetchGit
+    ${conix.lib.git.text}
+  );
+  }).conix.buildPages
+  [ (conix: { drv = with conix.lib; markdownFile "Volunteers" conix.vol; })
+    (conix: { vol = with conix.lib; texts [
 
-_Conix Sample_
-```nix
-${builtins.readFile ./sample.nix}
-```
+'''# Volunteer Handbook
 
-_markdown output_
-```markdown
-${builtins.readFile (import ./sample.nix)}
-```
+## Emergency Plan
+
+Incase of an emergency please contact: '''
+(t (conix.vol.contacts.at 2 0))" at "(t (conix.vol.contacts.at 2 1))'''.
+
+## Volunteer Contacts 
+
+_Volunteers still needed!: '''(t (8 - (builtins.length conix.vol.contacts.data)))'''_
+
+'''
+
+(set "contacts" (table
+    ["Name" "Phone" ]
+  [ ["John"   "555-123-4563"]
+    ["Jacob"  "555-321-9872"]
+    ["Jingle" "555-231-7589"]
+  ]
+))
+
+];})]
+
+'')''
 
 * The markdown sample was not hand written; the conix sample generated it.
 * The table in the markdown sample has some of its contents duplicated across


### PR DESCRIPTION
fixes issue where stack overflow encountered because of attempting to print derivations in printNixVal. A rewrite
of nixSnippet was the fix.