### PR TITLE
Adds `drvs` as part of modules

### DIFF
--- a/builder/pandoc.nix
+++ b/builder/pandoc.nix
@@ -6,11 +6,12 @@ conix: { lib = rec
       The list of derivation are extra buildInputs that pandoc should use.
     '';
     docs.pandoc.todo = [ "Remove hardcoded markdown input type" ];
-    docs.pandoc.type = "Type -> [ Derivation ] -> Name -> String -> (FilePath | Derivation) -> Derivation";
+    docs.pandoc.type = "Type -> [ Derivation ] -> Name -> String -> Module -> Derivation";
     pandoc 
-      = type: buildInputs: name: args: markdownFile:
+      = type: buildInputs: name: args: module:
       let
         fileName = "${name}.${type}";
+        markdownFile = conix.lib.markdownFile name module;
       in
         conix.pkgs.runCommand fileName
           { buildInputs = [ conix.pkgs.pandoc ] ++ buildInputs; }

--- a/codeSnippets.nix
+++ b/codeSnippets.nix
@@ -112,9 +112,9 @@ conix: { lib = rec
               ${conix.lib.indent 4 conix.lib.git.text}
             );
           }).conix.build
-          (conix: { sample = with conix.lib; using (markdownFile "${name}")
-            (${conix.lib.indent 2 code})
-          ;})
+          (conix: { sample = with conix.lib; using [(markdownFile "${name}")] (
+            ${conix.lib.indent 2 code}
+          );})
           '';
       in
       conix.lib.set name (snippet "nix" code (readConixResult sampleCodeFile));

--- a/codeSnippets.nix
+++ b/codeSnippets.nix
@@ -108,12 +108,10 @@ conix: { lib = rec
             overlays = import (builtins.fetchGit
               ${conix.lib.indent 4 conix.lib.git.text}
             );
-          }).conix.buildPages
-            [ (conix: { drv = with conix.lib; markdownFile "${name}" conix.sample; })
-              (conix: { sample = with conix.lib;
-                ${conix.lib.indent 6 code}
-              ;})
-            ]
+          }).conix.build
+          (conix: { sample = with conix.lib; dirWithMarkdown "${name}"
+            (${conix.lib.indent 2 code})
+          ;})
           '';
       in
         conix.lib.set name (snippet "nix" code "${builtins.readFile (import sampleCodeFile)}");

--- a/codeSnippets.nix
+++ b/codeSnippets.nix
@@ -84,7 +84,10 @@ conix: { lib = rec
       '';
     docs.runNixSnippetDrvFile.type = "Name -> String -> Module";
     runNixSnippetDrvFile = name: code: 
-      runSnippet name "nix" code (nixFilePath: "${builtins.readFile (import nixFilePath)}");
+      runSnippet name "nix" code readConixResult;
+
+    readConixResult = nixFile:
+      builtins.foldl' (s: d: "${s}\n${builtins.readFile d}") "" (import nixFile);
 
     docs.sampleConixSnippet.docstr = ''
       Creates a nix snippet using the given conix code. The content
@@ -109,11 +112,11 @@ conix: { lib = rec
               ${conix.lib.indent 4 conix.lib.git.text}
             );
           }).conix.build
-          (conix: { sample = with conix.lib; dirWithMarkdown "${name}"
+          (conix: { sample = with conix.lib; using (markdownFile "${name}")
             (${conix.lib.indent 2 code})
           ;})
           '';
       in
-        conix.lib.set name (snippet "nix" code "${builtins.readFile (import sampleCodeFile)}");
+      conix.lib.set name (snippet "nix" code (readConixResult sampleCodeFile));
   };
 }

--- a/conix.nix
+++ b/conix.nix
@@ -4,7 +4,7 @@ pkgs: { lib = rec {
     Modules are the core of conix. Their type is defined as:
    
     ```haskell
-    Module = { text : String; ... }
+    Module = { text : String; drvs = [Derivation]; ... }
     ```
    
     The rest of the attribute set defines the structure of the user's
@@ -14,7 +14,7 @@ pkgs: { lib = rec {
     look like:
    
     ```nix
-    { drv = <derivation>; 
+    { drvs = [<derivation>]; 
       text = "Call me at: 555-123-456"; 
       phone = "555-123-456"; 
     }
@@ -28,6 +28,12 @@ pkgs: { lib = rec {
 
     The empty module contains nothing. The core functions defined in this file
     treat the missing text value as an empty string to save memory.
+
+    The `drvs` field is the free monoid over (aka: list of) derivations. This
+    is because the core of conix needs to defer choosing how to combine module
+    derivations and leave that up to the user. In the future we may need to
+    just keep only a single drv and restrict how the derivations are combined
+    through "collect" and "dir". However, for now we'll defer this decision.
   '';
 
   docs.pages.discussion = ''TODO'';
@@ -47,8 +53,11 @@ pkgs: { lib = rec {
   docs.mergeModules.type = 
     "Module -> Module -> Module";
   mergeModules = a: b:
-    (pkgs.lib.attrsets.recursiveUpdate a b) 
-    // { text = (a.text or "") + (b.text or ""); };
+    (pkgs.lib.attrsets.recursiveUpdate a b)
+    //
+    { text = (a.text or "") + (b.text or ""); 
+      drvs = (a.drvs or []) ++ (b.drvs or []); 
+    };
 
   docs.mergePages.docstr = '' 
     A Page is the toplevel type used throughout conix. 

--- a/conix.nix
+++ b/conix.nix
@@ -147,6 +147,10 @@ pkgs: { lib = rec {
   texts 
     = foldMapModules toTextModule;
 
+  docs.nest.docstr = texts [''
+    Nest a value into an attribute set with a given path string.
+  ''];
+  docs.nest.type = "Path -> a -> AttrSet";
   nest = pathStr: x:
     pkgs.lib.attrsets.setAttrByPath (pkgs.lib.strings.splitString "." pathStr) x;
 
@@ -173,5 +177,21 @@ pkgs: { lib = rec {
     ```
     '';
   docs.set.type = "Path -> Module -> Module";
-  set = path: x: mergeModules (nest path x) (text x.text);
+  set = path: x: mergeModules (nest path x) ({ text = x.text or ""; drvs = x.drvs or []; });
+
+
+  # [ Derivation ] -> Module -> Module
+  docs.setDrvs.docstr = ''
+    Overwrite the derivations for the given module;
+    '';
+  docs.setDrvs.type = "[Derivation] -> Module -> Module";
+  setDrvs = drvs: module: module // { inherit drvs; };
+
+  # [ Derivation ] -> Module -> Module
+  docs.setText.docstr = ''
+    Overwrite the texts for the given module;
+    '';
+  docs.setText.type = "String -> Module -> Module";
+  setText = text: module: module // { inherit text; };
+
 };}

--- a/design/goals.nix
+++ b/design/goals.nix
@@ -1,4 +1,4 @@
-conix: with conix.lib; { lib.docs.goals = using (markdownFile "goals") (texts [
+conix: with conix.lib; { lib.docs.goals = using [(markdownFile "goals")] (texts [
 ''# Goals
 
 

--- a/design/goals.nix
+++ b/design/goals.nix
@@ -1,4 +1,5 @@
-conix: with conix.lib; { lib.docs.goals = using [(markdownFile "goals")] (texts [
+conix: with conix.lib; { lib.docs.goals = using [(markdownFile "goals") (htmlFile "goals" "--metadata title=goals")] (
+texts [
 ''# Goals
 
 

--- a/design/goals.nix
+++ b/design/goals.nix
@@ -1,4 +1,4 @@
-conix: with conix.lib; { lib.docs.goals = texts [
+conix: with conix.lib; { lib.docs.goals = using (markdownFile "goals") (texts [
 ''# Goals
 
 
@@ -152,4 +152,4 @@ Conix is not restricted to just markdown support. Currently, though, conix uses
 ${conix.lib.docs.readme.pandocLink} to render the markdown content and html
 files. However conix is easily extensible to support other build types.
 
-'']; }
+'']); }

--- a/docs.nix
+++ b/docs.nix
@@ -45,7 +45,7 @@ conix: { lib = rec
   mkDocs = docsAttrSet:
       collectDocModules (builtins.removeAttrs docsAttrSet ["text" "drv"]);
 
-  conixReferenceDocumentation = using [(markdownFile "docs") (htmlFile "docs" "--metadata title=docs")] (texts [
+  conixReferenceDocumentation = with conix.lib; using [(markdownFile "docs") (htmlFile "docs" "--metadata title=docs")] (texts [
       ''
       # Reference Documentation - ${conix.lib.version.text}
 
@@ -69,5 +69,5 @@ conix: { lib = rec
       ---
       Built using ${conix.lib.homePageLink} version ${conix.lib.version.text}
       ''
-    ];
+    ]);
 };}

--- a/documentation.nix
+++ b/documentation.nix
@@ -3,7 +3,7 @@
   (import ./design/goals.nix)
   (conix: { drv = with conix.lib;
     let
-      d = using (markdownFile "docs") (texts [ 
+      d = using [(markdownFile "docs")] (texts [ 
         ''
         # Reference Documentation - ${conix.lib.version.text}
 

--- a/documentation.nix
+++ b/documentation.nix
@@ -2,7 +2,7 @@
   (conix: { drv = with conix.lib;
     let
       c = collect "conix-docs" (
-        conixReferenceDocumentation
+        conixReferenceDocumentation.drvs
         ++ docs.readme.drvs
         ++ docs.goals.drvs
       );

--- a/documentation.nix
+++ b/documentation.nix
@@ -3,8 +3,8 @@
   (import ./design/goals.nix)
   (conix: { drv = with conix.lib;
     let
-      d = texts
-      [ ''
+      d = using (markdownFile "docs") (texts [ 
+        ''
         # Reference Documentation - ${conix.lib.version.text}
 
         ''
@@ -27,13 +27,13 @@
         ---
         Built using ${conix.lib.homePageLink} version ${conix.lib.version.text}
         ''
-      ];
+      ]);
 
-      c = collect "conix-docs" 
-        [ (buildBoth "docs" d (markdownFile "docs") (htmlFile "docs" ""))
-          (buildBoth "readme" docs.readme (markdownFile "readme") (htmlFile "readme" ""))
-          (buildBoth "goals" docs.goals (markdownFile "goals") (htmlFile "goals" ""))
-        ];
+      c = collect "conix-docs" (
+        d.drvs
+        ++ docs.readme.drvs
+        ++ docs.goals.drvs
+      );
     in
       { drvs = [ c ]; };
 })]

--- a/documentation.nix
+++ b/documentation.nix
@@ -3,7 +3,7 @@
   (import ./design/goals.nix)
   (conix: { drv = with conix.lib;
     let
-      d = using [(markdownFile "docs")] (texts [ 
+      d = using [(markdownFile "docs") (htmlFile "docs" "--metadata title=docs")] (texts [ 
         ''
         # Reference Documentation - ${conix.lib.version.text}
 

--- a/documentation.nix
+++ b/documentation.nix
@@ -1,5 +1,6 @@
 (import <nixpkgs> { overlays = (import ./default.nix); }).conix.buildPages [
   (conix: { drv = with conix.lib;
+    let
       c = collect "conix-docs" (
         conixReferenceDocumentation
         ++ docs.readme.drvs

--- a/documentation.nix
+++ b/documentation.nix
@@ -28,10 +28,12 @@
         Built using ${conix.lib.homePageLink} version ${conix.lib.version.text}
         ''
       ];
+
+      c = collect "conix-docs" 
+        [ (buildBoth "docs" d (markdownFile "docs") (htmlFile "docs" ""))
+          (buildBoth "readme" docs.readme (markdownFile "readme") (htmlFile "readme" ""))
+          (buildBoth "goals" docs.goals (markdownFile "goals") (htmlFile "goals" ""))
+        ];
     in
-    collect "conix-docs" 
-      [ (buildBoth "docs" d (markdownFile "docs") (htmlFile "docs" ""))
-        (buildBoth "readme" docs.readme (markdownFile "readme") (htmlFile "readme" ""))
-        (buildBoth "goals" docs.goals (markdownFile "goals") (htmlFile "goals" ""))
-      ];
+      { drvs = [ c ]; };
 })]

--- a/drvs.nix
+++ b/drvs.nix
@@ -22,34 +22,23 @@ conix: { lib = rec
     It's more likely you'll use this instead of `using_`.
   '';
   docs.using.type = "[(Module -> Derivation)] -> Module -> Module";
-  using = fs: using_ (a: builtins.map (f: f a) fs) 
+  using = fs: using_ apply1
 
   docs.as.docstr = builtins.replaceStrings ["using_"] ["as_"] docs.using.docstr;
   docs.as.type = docs.using.type;
-  as = fs: as_ (a: builtins.map (f: f a) fs) 
+  as = fs: as_ apply1
 
-  docs.dirWithMarkdown.docstr = ''
-    Create a directory called `name` and within it a markdown file called
-    `name` whos text is from the given module. The directory also contains
-    files produced by any deririvations created in the given module. These
-    files are aggregated using `dir`.
+  docs.usingDir.docstr = ''
+    Like `using` but nest all of the created derivations under a directory with
+    the given name.
+    '';
+  docs.usingDir.type = "Name -> [(Module -> Derivation)] -> Module -> Module";
+  usingDir = name: fs: using_ (m: conix.lib.dir name (apply1 fs m));
 
-    Use this as your toplevel file derivation.
+  docs.asDir.docstr = builtins.replaceStrings ["`using`"] ["`as`"] docs.usingDir.docstr;
+  docs.asDir.type = docs.usingDir.type;
+  asDir = name: fs: as_ (m: conix.lib.dir name (apply1 fs m));
 
-    The returned module's
-    ```
-    A 
-      |- A.md
-      |- ... <any otherfiles from the given module's drvs>
-    ```
-  '';
-
-  docs.dirWithMarkdown.type = "Name -> Module -> Module";
-  dirWithMarkdown = name: module: 
-    as (m: conix.lib.dir name m.drvs) (using (conix.lib.markdownFile name) module);
-
-  docs.collectWithMarkdown.docstr = builtins.replaceStrings ["`dir`"] ["`collect`"] docs.dirWithMarkdown.docstr;
-  docs.collectWithMarkdown.type = "Name -> Module -> Module";
-  collectWithMarkdown = name: module: 
-    as (m: conix.lib.collect name m.drvs) (using (conix.lib.markdownFile name) module);
+  # [(a -> b)] -> a -> [b]
+  apply1 = fs: x: builtins.map (f: f x) fs;
 }; }

--- a/drvs.nix
+++ b/drvs.nix
@@ -8,6 +8,13 @@ conix: { lib = rec
   docs.using.type = "(Module -> Derivation) -> Module -> Module";
   using = f: module: conix.lib.mergeModules module ({ drvs = [ (f module) ]; });
 
+  docs.as.docstr = ''
+    Like `using` but instead of appending the generated derivation, it sets the
+    drvs to the generated derivation.
+  '';
+  docs.as.type = "(Module -> Derivation) -> Module -> Module";
+  as = f: module: conix.lib.setDrvs [ (f module) ] module;
+
   docs.dirWithMarkdown.docstr = ''
     Create a directory called `name` and within it a markdown file called
     `name` whos text is from the given module. The directory also contains
@@ -15,15 +22,22 @@ conix: { lib = rec
     files are aggregated using `dir`.
 
     Use this as your toplevel file derivation.
+
+    The returned module's
+    ```
+    A 
+      |- A.md
+      |- ... <any otherfiles from the given module's drvs>
+    ```
   '';
 
   docs.dirWithMarkdown.type = "Name -> Module -> Module";
   dirWithMarkdown = name: module: 
-    using (m: conix.lib.dir name m.drvs) (using (conix.lib.markdownFile name) module);
+    as (m: conix.lib.dir name m.drvs) (using (conix.lib.markdownFile name) module);
 
   docs.collectWithMarkdown.docstr = builtins.replaceStrings ["`dir`"] ["`collect`"];
   docs.collectWithMarkdown.type = "Name -> Module -> Module";
   collectWithMarkdown = name: module: 
-    using (m: conix.lib.collect name m.drvs) (using (conix.lib.markdownFile name) module);
+    as (m: conix.lib.collect name m.drvs) (using (conix.lib.markdownFile name) module);
 
 }; }

--- a/drvs.nix
+++ b/drvs.nix
@@ -1,0 +1,29 @@
+conix: { lib = rec
+{
+  
+  docs.using.docstr = ''
+    Constructs a derivation from the given module, and then appends
+    that to the module's derivations. 
+  '';
+  docs.using.type = "(Module -> Derivation) -> Module -> Module";
+  using = f: module: conix.lib.mergeModules module ({ drvs = [ (f module) ]; });
+
+  docs.dirWithMarkdown.docstr = ''
+    Create a directory called `name` and within it a markdown file called
+    `name` whos text is from the given module. The directory also contains
+    files produced by any deririvations created in the given module. These
+    files are aggregated using `dir`.
+
+    Use this as your toplevel file derivation.
+  '';
+
+  docs.dirWithMarkdown.type = "Name -> Module -> Module";
+  dirWithMarkdown = name: module: 
+    using (m: conix.lib.dir name m.drvs) (using (markdownFile name) module);
+
+  docs.collectWithMarkdown.docstr = builtins.replaceStrings ["`dir`"] ["`collect`"];
+  docs.collectWithMarkdown.type = "Name -> Module -> Module";
+  collectWithMarkdown = name: module: 
+    using (m: conix.lib.collect name m.drvs) (using (markdownFile name) module);
+
+}; }

--- a/drvs.nix
+++ b/drvs.nix
@@ -1,19 +1,32 @@
 conix: { lib = rec
 {
   
-  docs.using.docstr = ''
-    Constructs a derivation from the given module, and then appends
+  docs.using_.docstr = ''
+    Constructs derivations from the given module, and then append
     that to the module's derivations. 
   '';
-  docs.using.type = "[(Module -> Derivation)] -> Module -> Module";
-  using = fs: module: conix.lib.mergeModules module ({ drvs = builtins.map (f: f module) fs; });
+  docs.using_.type = "(Module -> [Derivation]) -> Module -> Module";
+  using_ = f: module: conix.lib.mergeModules module ({ drvs = f module; });
 
-  docs.as.docstr = ''
-    Like `using` but instead of appending the generated derivation, it sets the
-    drvs to the generated derivation.
+  docs.as_.docstr = ''
+    Construct derivations from the given module and then replace that modules
+    derivations with the constructed ones.
   '';
-  docs.as.type = "[(Module -> Derivation)] -> Module -> Module";
-  as = fs: module: conix.lib.setDrvs (builtins.map (f: f module) fs) module;
+  docs.as_.type = "(Module -> [Derivation]) -> Module -> Module";
+  as_ = f: module: conix.lib.setDrvs (f module) module;
+
+  docs.using.docstr = ''
+    Like `using_` but uses a list of functions that return a single derivation 
+    each.
+
+    It's more likely you'll use this instead of `using_`.
+  '';
+  docs.using.type = "[(Module -> Derivation)] -> Module -> Module";
+  using = fs: using_ (a: builtins.map (f: f a) fs) 
+
+  docs.as.docstr = builtins.replaceStrings ["using_"] ["as_"] docs.using.docstr;
+  docs.as.type = docs.using.type;
+  as = fs: as_ (a: builtins.map (f: f a) fs) 
 
   docs.dirWithMarkdown.docstr = ''
     Create a directory called `name` and within it a markdown file called

--- a/drvs.nix
+++ b/drvs.nix
@@ -5,15 +5,15 @@ conix: { lib = rec
     Constructs a derivation from the given module, and then appends
     that to the module's derivations. 
   '';
-  docs.using.type = "(Module -> Derivation) -> Module -> Module";
-  using = f: module: conix.lib.mergeModules module ({ drvs = [ (f module) ]; });
+  docs.using.type = "[(Module -> Derivation)] -> Module -> Module";
+  using = fs: module: conix.lib.mergeModules module ({ drvs = builtins.map (f: f module) fs; });
 
   docs.as.docstr = ''
     Like `using` but instead of appending the generated derivation, it sets the
     drvs to the generated derivation.
   '';
-  docs.as.type = "(Module -> Derivation) -> Module -> Module";
-  as = f: module: conix.lib.setDrvs [ (f module) ] module;
+  docs.as.type = "[(Module -> Derivation)] -> Module -> Module";
+  as = fs: module: conix.lib.setDrvs (builtins.map (f: f module) fs) module;
 
   docs.dirWithMarkdown.docstr = ''
     Create a directory called `name` and within it a markdown file called
@@ -39,5 +39,4 @@ conix: { lib = rec
   docs.collectWithMarkdown.type = "Name -> Module -> Module";
   collectWithMarkdown = name: module: 
     as (m: conix.lib.collect name m.drvs) (using (conix.lib.markdownFile name) module);
-
 }; }

--- a/drvs.nix
+++ b/drvs.nix
@@ -19,11 +19,11 @@ conix: { lib = rec
 
   docs.dirWithMarkdown.type = "Name -> Module -> Module";
   dirWithMarkdown = name: module: 
-    using (m: conix.lib.dir name m.drvs) (using (markdownFile name) module);
+    using (m: conix.lib.dir name m.drvs) (using (conix.lib.markdownFile name) module);
 
   docs.collectWithMarkdown.docstr = builtins.replaceStrings ["`dir`"] ["`collect`"];
   docs.collectWithMarkdown.type = "Name -> Module -> Module";
   collectWithMarkdown = name: module: 
-    using (m: conix.lib.collect name m.drvs) (using (markdownFile name) module);
+    using (m: conix.lib.collect name m.drvs) (using (conix.lib.markdownFile name) module);
 
 }; }

--- a/drvs.nix
+++ b/drvs.nix
@@ -22,11 +22,11 @@ conix: { lib = rec
     It's more likely you'll use this instead of `using_`.
   '';
   docs.using.type = "[(Module -> Derivation)] -> Module -> Module";
-  using = fs: using_ apply1
+  using = fs: using_ (apply1 fs);
 
   docs.as.docstr = builtins.replaceStrings ["using_"] ["as_"] docs.using.docstr;
   docs.as.type = docs.using.type;
-  as = fs: as_ apply1
+  as = fs: as_ (apply1 fs);
 
   docs.usingDir.docstr = ''
     Like `using` but nest all of the created derivations under a directory with

--- a/drvs.nix
+++ b/drvs.nix
@@ -35,7 +35,7 @@ conix: { lib = rec
   dirWithMarkdown = name: module: 
     as (m: conix.lib.dir name m.drvs) (using (conix.lib.markdownFile name) module);
 
-  docs.collectWithMarkdown.docstr = builtins.replaceStrings ["`dir`"] ["`collect`"];
+  docs.collectWithMarkdown.docstr = builtins.replaceStrings ["`dir`"] ["`collect`"] docs.dirWithMarkdown.docstr;
   docs.collectWithMarkdown.type = "Name -> Module -> Module";
   collectWithMarkdown = name: module: 
     as (m: conix.lib.collect name m.drvs) (using (conix.lib.markdownFile name) module);

--- a/drvs.nix
+++ b/drvs.nix
@@ -33,11 +33,11 @@ conix: { lib = rec
     the given name.
     '';
   docs.usingDir.type = "Name -> [(Module -> Derivation)] -> Module -> Module";
-  usingDir = name: fs: using_ (m: conix.lib.dir name (apply1 fs m));
+  usingDir = name: fs: using_ (m: [ (conix.lib.dir name (apply1 fs m)) ]);
 
   docs.asDir.docstr = builtins.replaceStrings ["`using`"] ["`as`"] docs.usingDir.docstr;
   docs.asDir.type = docs.usingDir.type;
-  asDir = name: fs: as_ (m: conix.lib.dir name (apply1 fs m));
+  asDir = name: fs: as_ (m: [ (conix.lib.dir name (apply1 fs m))] );
 
   # [(a -> b)] -> a -> [b]
   apply1 = fs: x: builtins.map (f: f x) fs;

--- a/eval.nix
+++ b/eval.nix
@@ -51,6 +51,7 @@ in
               (import ./docs.nix)
               (import ./copyJoin.nix)
               (import ./foldAttr.nix)
+              (import ./drvs.nix)
               (x: core)
               # This is the docs attribute set defined in this file
               (x: { lib.docs = docs; }) 

--- a/eval.nix
+++ b/eval.nix
@@ -7,23 +7,16 @@ in
 { conix = rec
   { 
     docs.build.docstr = ''
-      Builds a page that expects the toplevel module to contain an attribute called `drv`.
-      Drv typically should be a derivation containing the toplevel render of the content
+      Builds a page and collects all of the derivations from the toplevel modules.
+      Use this to build the final output of your content.
     '';
-    docs.build.todo = [ 
-      ''
-      The current implementation of build needs to take in a separate set of
-      pages that are the actual content from the user. And then a single module
-      that defines how to build the top derivation. If done, this may need to
-      remove the clunky user interface for needing to define a toplevel
-      attribute set with a single name and then turn around and give builders
-      (like `markdownFile`) a name - this is redundant.
-      ''
-    ];
     docs.build.type 
-      = "Page -> Derivation";
+      = "Page -> [Derivation]";
     build
-      = page: (eval page).drv;
+      = page: builtins.foldl' 
+        (drvs: mod: drvs ++ (mod.drvs or [])) 
+        [] 
+        (builtins.attrValues (eval page));
 
     docs.buildPages.docstr = ''
       Merges the pages into one and then calls `build`.

--- a/readme/default.nix
+++ b/readme/default.nix
@@ -1,4 +1,4 @@
-conix: with conix.lib; { lib.docs.readme = texts [
+conix: with conix.lib; { lib.docs.readme = using (markdownFile "readme") (texts [
 ''# ${homePageLink} - ${version.text} - ${buildBadgeLink}
 
 ${if conix.lib.version.major < 1
@@ -84,4 +84,4 @@ Many thanks to:
   * [Evan Relf](https://github.com/evanrelf) for his insightful feedback.
   * [Paul Young](https://github.com/paulyoung) for great feedback and ideas.
 
-'']; }
+'']); }

--- a/readme/default.nix
+++ b/readme/default.nix
@@ -1,4 +1,4 @@
-conix: with conix.lib; { lib.docs.readme = using (markdownFile "readme") (texts [
+conix: with conix.lib; { lib.docs.readme = using [(markdownFile "readme")] (texts [
 ''# ${homePageLink} - ${version.text} - ${buildBadgeLink}
 
 ${if conix.lib.version.major < 1
@@ -30,7 +30,7 @@ To try out conix:
   overlays = import (builtins.fetchGit
     ${indent 4 conix.lib.git.text}
   );
-}).conix.build (conix: { vol = with conix.lib; using (markdownFile "Volunteers") (texts [
+}).conix.build (conix: { vol = with conix.lib; using [(markdownFile "Volunteers")] (texts [
 
 '''# Volunteer Handbook
 

--- a/readme/default.nix
+++ b/readme/default.nix
@@ -1,4 +1,5 @@
-conix: with conix.lib; { lib.docs.readme = using [(markdownFile "readme")] (texts [
+conix: with conix.lib; { lib.docs.readme = using [(markdownFile "readme") (htmlFile "readme" "--metadata title=readme")] 
+(texts [
 ''# ${homePageLink} - ${version.text} - ${buildBadgeLink}
 
 ${if conix.lib.version.major < 1

--- a/readme/default.nix
+++ b/readme/default.nix
@@ -30,9 +30,7 @@ To try out conix:
   overlays = import (builtins.fetchGit
     ${indent 4 conix.lib.git.text}
   );
-}).conix.buildPages
-  [ (conix: { drv = with conix.lib; markdownFile "Volunteers" conix.vol; })
-    (conix: { vol = with conix.lib; texts [
+}).conix.build (conix: { vol = with conix.lib; using (markdownFile "Volunteers") (texts [
 
 '''# Volunteer Handbook
 
@@ -55,9 +53,8 @@ _Volunteers still needed!: '''(t (8 - (builtins.length conix.vol.contacts.data))
   ]
 ))
 
-];})]
-
-'')''
+]);})''
+)''
 
 * The markdown sample was not hand written; the conix sample generated it.
 * The table in the markdown sample has some of its contents duplicated across

--- a/test.nix
+++ b/test.nix
@@ -29,6 +29,6 @@ rec {
       })
       (x: { s = with x.lib; texts [ (sampleConixSnippet "t" "texts [ \"foo\" ]") ]; })
       (x: { t = with x.lib; asMd "foo" (texts [ "asdf: " (t x.t.x) { x = 3; } ]); })
-      (x: { u = with x.lib; dirWithMarkdown "foo" (texts [ "boo" (asMd "joe" (text "jack")) ]); })
+      (x: { u = with x.lib; dirWithMarkdown "foo" (texts [ "boo" (using (markdownFile "joe") (text "jack")) ]); })
     ];
 }

--- a/test.nix
+++ b/test.nix
@@ -1,11 +1,9 @@
-# Module = ReaderT AttrSet (Writer AttrSet)
-# 
-# type Pages = AttrSet
-# BuildPageSet :: Module -> AttrSet 
-let
+rec {
 
   # this is the toplevel agreggation of the modules in question
   pkgs = import <nixpkgs> { overlays = (import ./default.nix); };
+
+  conix = pkgs.conix;
 
   docs = pkgs.conix.buildPages [
     (c: { drv = with c.lib; 
@@ -13,6 +11,7 @@ let
     })
     (import ./design/goals.nix)
   ];
+
 
   test = pkgs.conix.evalPages
     [ 
@@ -29,11 +28,7 @@ let
         ];
       })
       (x: { s = with x.lib; texts [ (sampleConixSnippet "t" "texts [ \"foo\" ]") ]; })
+      (x: { t = with x.lib; asMd "foo" (texts [ "asdf: " (t x.t.x) { x = 3; } ]); })
+      (x: { u = with x.lib; dirWithMarkdown "foo" (texts [ "boo" (asMd "joe" (text "jack")) ]); })
     ];
-
-in
-  { 
-    inherit (pkgs) conix;
-    inherit test; 
-    inherit docs;
-  }
+}

--- a/test.nix
+++ b/test.nix
@@ -29,6 +29,6 @@ rec {
       })
       (x: { s = with x.lib; texts [ (sampleConixSnippet "t" "texts [ \"foo\" ]") ]; })
       (x: { t = with x.lib; asMd "foo" (texts [ "asdf: " (t x.t.x) { x = 3; } ]); })
-      (x: { u = with x.lib; dirWithMarkdown "foo" (texts [ "boo" (using (markdownFile "joe") (text "jack")) ]); })
+      (x: { u = with x.lib; dirWithMarkdown "foo" (texts [ "boo" (using [(markdownFile "joe")] (text "jack")) ]); })
     ];
 }


### PR DESCRIPTION
This adds `drvs` as part of the module type. This allows us to push creating derivations as part of conix evaluation instead of needing to manually create pages that consume other parts of the content tree. As a result `build` is simplified, and users can specify how a page file should build within the file itself without needing a separate toplevel module stuck in `drv`. Further, this should pave the way to auto-generating links for content. 