### PR TITLE
Add `nest` as part of core language

### DIFF
--- a/contentTest.nix
+++ b/contentTest.nix
@@ -26,6 +26,7 @@ rec
 
       ''
       ...or here
+
       ''
 
       (markdown "mdListSample" [ "  " (indent 2 
@@ -63,7 +64,13 @@ rec
       ''
       (runNixSnippet "foo" ''
         1 + 2
-      '')
+      '')''
+
+
+      ''(nest "y" (n: with n; [{ x = 4; } " = " (r data.x)]))''
+
+
+      ''(r data.y.x)" = 4 != "(r data.x)
     ]);
 
   h_ = pkgs.conix.run h;

--- a/lib/conix.nix
+++ b/lib/conix.nix
@@ -62,6 +62,32 @@ rec
       _text
     ;
 
+  nest = expr
+    "PathString -> Content -> Content"
+    ''
+    Nest the data for the given content under a given path
+
+    For example:
+
+    ```nix
+      m: with m;
+      [
+        (nest "foo.bar" (n: with n; [{ x = 3; } (r data.x)]))
+        {x = 4;}
+
+        (r data.x)
+      ]
+    will produce:
+
+    ```nix
+    "3344"
+    ```
+    notice how we've defined `x` in two places.
+    ```
+    ''
+    (_path: _next: internalLib._nest { inherit _path _next; })
+    ;
+
   t = text;
 
   ref = expr 

--- a/lib/eval.nix
+++ b/lib/eval.nix
@@ -61,7 +61,11 @@ rec
       # passing down to generation function. This is used to
       # undo the effect of `nestPath`.
       unnestData = path: f: x:
-        f (x // (pkgs.lib.attrsets.getAttrFromPath path x));
+        f { 
+          drv = x.drv;
+          text = x.text;
+          data = x.data // (pkgs.lib.attrsets.getAttrFromPath path x.data);
+        };
 
       # a -> ResF a
       pure = drv: _: { text = ""; inherit drv; data = {}; };

--- a/lib/internal.nix
+++ b/lib/internal.nix
@@ -164,20 +164,21 @@ rec
   docs._ref.type = "a -> ContentF a";
   _ref = T.typed "ref";
 
+  docs._nest.type = "PathString -> a -> ContentF a";
+  _nest = T.typed "nest";
+
   fmapMatch = f:
     { 
-      "tell"  = _data: _tell _data;
-      "text"  = x: _text x;
-      "local" = x: _local x;
-      "file"  = {_mkFile, _next}: 
-        _file { inherit _mkFile; _next = f _next; };
-      "dir" = {_dirName, _next}:
-        _dir { inherit _dirName; _next = f _next; };
-      "indent" = {_nSpaces, _next}:
-        _indent { inherit _nSpaces; _next = f _next; };
-      "merge" = xs: _merge (builtins.map f xs);
-      "using" = g: _using (x: f (g x));
-      "ref" = x: _ref (f x);
+      tell   = _data: _tell _data;
+      text   = x: _text x;
+      local  = x: _local x;
+      file   = {_mkFile, _next}: _file { inherit _mkFile; _next = f _next; };
+      dir    = {_dirName, _next}: _dir { inherit _dirName; _next = f _next; };
+      indent = {_nSpaces, _next}: _indent { inherit _nSpaces; _next = f _next; };
+      merge  = xs: _merge (builtins.map f xs);
+      using  = g: _using (x: f (g x));
+      ref    = x: _ref (f x);
+      nest   = {_path, _next}: _nest { inherit _path; _next = f _next; };
     };
 
   fmap = T.matchWith fmapMatch;


### PR DESCRIPTION
This allows explicit nesting and local scoping of `data`. The main use case for this is to allow a user to include another expression that contains assignments that might clash with the assignments in the current expression.